### PR TITLE
feat(android): add PTT mode with forceStop and continuousPTT

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,9 +466,13 @@ Raised whenever a segmented result is produced (Android only).
 
 Raised whenever a partial transcription is produced.
 
-| Prop          | Type                  |
-| ------------- | --------------------- |
-| **`matches`** | <code>string[]</code> |
+| Prop                  | Type                  | Description                                                                |
+| --------------------- | --------------------- | -------------------------------------------------------------------------- |
+| **`matches`**         | <code>string[]</code> |                                                                            |
+| **`accumulated`**     | <code>string</code>   | Accumulated transcription across continuous PTT restarts (Android only).   |
+| **`accumulatedText`** | <code>string</code>   | Final accumulated text including the current result (Android only).        |
+| **`isRestarting`**    | <code>boolean</code>  | True when recognition is restarting in continuous PTT mode (Android only). |
+| **`forced`**          | <code>boolean</code>  | True when result was emitted due to force stop timeout (Android only).     |
 
 
 #### SpeechRecognitionListeningEvent

--- a/README.md
+++ b/README.md
@@ -160,7 +160,9 @@ doesn't always stop audio capture reliably.
 This method:
 1. Tries graceful stopListening() first
 2. After timeout, forces stop by destroying and recreating the recognizer
-3. Returns the last cached partial result so no speech is lost
+3. Emits the last cached partial result via the `partialResults` event
+
+To retrieve the last transcription after force stop, use {@link getLastPartialResult}.
 
 | Param         | Type                                                          | Description                      |
 | ------------- | ------------------------------------------------------------- | -------------------------------- |

--- a/android/src/main/java/app/capgo/speechrecognition/SpeechRecognitionPlugin.java
+++ b/android/src/main/java/app/capgo/speechrecognition/SpeechRecognitionPlugin.java
@@ -115,6 +115,13 @@ public class SpeechRecognitionPlugin extends Plugin implements Constants {
             )
         );
 
+        // Cancel any pending force-stop timeout from a previous session
+        if (forceStopRunnable != null) {
+            pttHandler.removeCallbacks(forceStopRunnable);
+            forceStopRunnable = null;
+        }
+        forceStopped = false;
+
         // Store config for potential restarts in continuous PTT mode
         this.continuousPTTMode = continuousPTT;
         this.lastLanguage = language;

--- a/android/src/main/java/app/capgo/speechrecognition/SpeechRecognitionPlugin.java
+++ b/android/src/main/java/app/capgo/speechrecognition/SpeechRecognitionPlugin.java
@@ -411,11 +411,15 @@ public class SpeechRecognitionPlugin extends Plugin implements Constants {
                         speechRecognizer.setRecognitionListener(listener);
                         speechRecognizer.startListening(intent);
                         listening(true);
-                        if (partialResults) {
+                        if (partialResults && call != null) {
                             call.resolve();
                         }
                     } catch (Exception ex) {
-                        call.reject(ex.getMessage());
+                        if (call != null) {
+                            call.reject(ex.getMessage());
+                        } else {
+                            Logger.error(TAG, "Error during continuousPTT restart", ex);
+                        }
                     } finally {
                         lock.unlock();
                     }

--- a/example-app/android/build.gradle
+++ b/example-app/android/build.gradle
@@ -22,6 +22,13 @@ allprojects {
         google()
         mavenCentral()
     }
+    configurations.all {
+        resolutionStrategy {
+            force 'org.jetbrains.kotlin:kotlin-stdlib:1.9.24'
+            force 'org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.9.24'
+            force 'org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.9.24'
+        }
+    }
 }
 
 task clean(type: Delete) {

--- a/example-app/android/build.gradle
+++ b/example-app/android/build.gradle
@@ -9,6 +9,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:8.13.0'
         classpath 'com.google.gms:google-services:4.4.2'
+        classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.24'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/example-app/index.html
+++ b/example-app/index.html
@@ -28,6 +28,10 @@
             <span>Listening</span>
             <strong id="listening">no</strong>
           </div>
+          <div id="ptt-status-container" class="hidden">
+            <span>PTT State</span>
+            <strong id="ptt-state">released</strong>
+          </div>
         </div>
         <div class="button-row">
           <button id="check-availability">Check Availability</button>
@@ -67,10 +71,36 @@
             <input id="add-punctuation" type="checkbox" />
             <span>Add punctuation (iOS 16+)</span>
           </label>
+
+          <div class="form-divider">
+            <span>PTT Mode (Android)</span>
+          </div>
+
+          <label class="checkbox">
+            <input id="ptt-mode" type="checkbox" />
+            <span>Enable PTT mode</span>
+          </label>
+
+          <label class="checkbox">
+            <input id="continuous-ptt" type="checkbox" disabled />
+            <span>Continue on silence (experimental)</span>
+          </label>
         </div>
         <div class="button-row">
           <button id="start-listening">Start Listening</button>
           <button id="stop-listening" class="ghost">Stop</button>
+        </div>
+
+        <div id="ptt-controls" class="ptt-controls hidden">
+          <p class="ptt-instructions">Hold the button to record. Release to stop.</p>
+          <button id="ptt-button" class="ptt-button">
+            <span class="ptt-icon">🎤</span>
+            <span class="ptt-label">Hold to Talk</span>
+          </button>
+          <div id="accumulated-results" class="accumulated-results hidden">
+            <strong>Accumulated:</strong>
+            <span id="accumulated-text"></span>
+          </div>
         </div>
       </section>
 

--- a/example-app/src/main.js
+++ b/example-app/src/main.js
@@ -36,7 +36,7 @@ function appendEvent(label, detail) {
   body.textContent = detail ? `${label}: ${detail}` : label;
   entry.appendChild(time);
   entry.appendChild(body);
-  if (refs.eventLog.firstChild?.classList.contains('muted')) {
+  if (refs.eventLog.firstChild?.classList?.contains('muted')) {
     refs.eventLog.innerHTML = '';
   }
   refs.eventLog.prepend(entry);

--- a/example-app/src/main.js
+++ b/example-app/src/main.js
@@ -18,12 +18,25 @@ const refs = {
   requestPermission: document.getElementById('request-permission'),
   startListening: document.getElementById('start-listening'),
   stopListening: document.getElementById('stop-listening'),
+  // PTT refs
+  pttMode: document.getElementById('ptt-mode'),
+  continuousPTT: document.getElementById('continuous-ptt'),
+  pttControls: document.getElementById('ptt-controls'),
+  pttButton: document.getElementById('ptt-button'),
+  pttState: document.getElementById('ptt-state'),
+  pttStatusContainer: document.getElementById('ptt-status-container'),
+  accumulatedResults: document.getElementById('accumulated-results'),
+  accumulatedText: document.getElementById('accumulated-text'),
 };
 
 let partialListener;
 let listeningListener;
 let segmentListener;
 let segmentedSessionListener;
+
+// PTT mode state
+let pttModeEnabled = false;
+let isPTTHeld = false;
 
 const formatTime = () => new Date().toLocaleTimeString();
 
@@ -80,11 +93,28 @@ function syncListeningState(status) {
   refs.listening.textContent = active ? 'yes' : 'no';
 }
 
+function togglePTTMode(enabled) {
+  pttModeEnabled = enabled;
+  refs.pttControls.classList.toggle('hidden', !enabled);
+  refs.startListening.parentElement.classList.toggle('hidden', enabled);
+  refs.pttStatusContainer.classList.toggle('hidden', !enabled);
+  refs.continuousPTT.disabled = !enabled;
+  if (!enabled) refs.continuousPTT.checked = false;
+  appendEvent('PTT Mode', enabled ? 'enabled' : 'disabled');
+}
+
 async function ensureListeners() {
   if (!partialListener) {
     partialListener = await SpeechRecognition.addListener('partialResults', (event) => {
       const matches = event.matches?.join(' | ') ?? '(empty)';
-      appendEvent('partialResults', matches);
+      if (event.accumulated) {
+        refs.accumulatedText.textContent = event.accumulated;
+        refs.accumulatedResults.classList.remove('hidden');
+        const detail = event.isRestarting ? `${matches} [restarting...]` : matches;
+        appendEvent('partialResults', `${detail} (accumulated: ${event.accumulated})`);
+      } else {
+        appendEvent('partialResults', matches);
+      }
     });
   }
 
@@ -121,6 +151,7 @@ function parseOptions() {
     popup: refs.popup.checked,
     addPunctuation: refs.addPunctuation.checked,
     allowForSilence,
+    continuousPTT: pttModeEnabled && refs.continuousPTT.checked,
   };
   return options;
 }
@@ -150,12 +181,73 @@ async function stopListening() {
   }
 }
 
+async function handlePTTPress() {
+  if (isPTTHeld) return;
+  isPTTHeld = true;
+  refs.pttButton.classList.add('active');
+  refs.pttState.textContent = 'held';
+  refs.accumulatedResults.classList.add('hidden');
+  refs.accumulatedText.textContent = '';
+
+  try {
+    await SpeechRecognition.setPTTState({ held: true });
+    appendEvent('setPTTState()', 'held: true');
+    await ensureListeners();
+    const options = parseOptions();
+    appendEvent('start() [PTT]', JSON.stringify(options));
+    await SpeechRecognition.start(options);
+  } catch (error) {
+    appendEvent('PTT start error', error?.message ?? String(error));
+    handlePTTRelease();
+  }
+}
+
+async function handlePTTRelease() {
+  if (!isPTTHeld) return;
+  isPTTHeld = false;
+  refs.pttButton.classList.remove('active');
+  refs.pttState.textContent = 'released';
+
+  try {
+    await SpeechRecognition.setPTTState({ held: false });
+    appendEvent('setPTTState()', 'held: false');
+    appendEvent('forceStop()', 'requesting...');
+    await SpeechRecognition.forceStop({ timeout: 1500 });
+    appendEvent('forceStop()', 'completed');
+    const lastResult = await SpeechRecognition.getLastPartialResult();
+    if (lastResult.available) {
+      appendEvent('getLastPartialResult()', lastResult.text);
+    }
+  } catch (error) {
+    appendEvent('PTT stop error', error?.message ?? String(error));
+  }
+}
+
 async function bootstrap() {
   refs.checkAvailability.addEventListener('click', updateAvailability);
   refs.checkPermission.addEventListener('click', updatePermissions);
   refs.requestPermission.addEventListener('click', requestPermissions);
   refs.startListening.addEventListener('click', startListening);
   refs.stopListening.addEventListener('click', stopListening);
+
+  // PTT mode toggle
+  refs.pttMode.addEventListener('change', (e) => togglePTTMode(e.target.checked));
+
+  // PTT button - mouse events
+  refs.pttButton.addEventListener('mousedown', handlePTTPress);
+  refs.pttButton.addEventListener('mouseup', handlePTTRelease);
+  refs.pttButton.addEventListener('mouseleave', handlePTTRelease);
+
+  // PTT button - touch events
+  refs.pttButton.addEventListener('touchstart', (e) => {
+    e.preventDefault();
+    handlePTTPress();
+  });
+  refs.pttButton.addEventListener('touchend', (e) => {
+    e.preventDefault();
+    handlePTTRelease();
+  });
+  refs.pttButton.addEventListener('touchcancel', handlePTTRelease);
 
   await Promise.all([updateAvailability(), updatePermissions()]);
 }

--- a/example-app/src/style.css
+++ b/example-app/src/style.css
@@ -195,3 +195,104 @@ input[type='checkbox'] {
     text-align: center;
   }
 }
+
+/* PTT Mode Styles */
+
+.hidden {
+  display: none !important;
+}
+
+.form-divider {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  margin: 0.5rem 0;
+  color: #94a3b8;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.form-divider::before,
+.form-divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.ptt-controls {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: 1rem 0;
+}
+
+.ptt-instructions {
+  margin: 0;
+  color: #94a3b8;
+  font-size: 0.9rem;
+}
+
+.ptt-button {
+  width: 120px;
+  height: 120px;
+  border-radius: 50%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  background: linear-gradient(135deg, #3b82f6, #6366f1);
+  border: 4px solid rgba(255, 255, 255, 0.2);
+  color: white;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+  box-shadow: 0 8px 24px rgba(59, 130, 246, 0.4);
+  user-select: none;
+  -webkit-user-select: none;
+  touch-action: manipulation;
+}
+
+.ptt-button:hover {
+  transform: scale(1.05);
+}
+
+.ptt-button:active,
+.ptt-button.active {
+  transform: scale(0.95);
+  background: linear-gradient(135deg, #ef4444, #f97316);
+  box-shadow: 0 4px 16px rgba(239, 68, 68, 0.5);
+}
+
+.ptt-icon {
+  font-size: 2rem;
+}
+
+.ptt-label {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+
+.accumulated-results {
+  background: rgba(34, 211, 238, 0.1);
+  border: 1px solid rgba(34, 211, 238, 0.3);
+  border-radius: 12px;
+  padding: 0.75rem 1rem;
+  width: 100%;
+  max-width: 400px;
+}
+
+.accumulated-results strong {
+  color: #22d3ee;
+  font-size: 0.85rem;
+  display: block;
+  margin-bottom: 0.25rem;
+}
+
+label.checkbox input[type='checkbox']:disabled + span {
+  opacity: 0.5;
+}

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -176,6 +176,7 @@ export interface SpeechRecognitionPlugin {
    *
    * To retrieve the last transcription after force stop, use {@link getLastPartialResult}.
    *
+   * @platform Android
    * @param options - Optional timeout configuration
    */
   forceStop(options?: ForceStopOptions): Promise<void>;
@@ -184,6 +185,8 @@ export interface SpeechRecognitionPlugin {
    *
    * Useful for retrieving what was heard before a force stop,
    * or checking the current partial state at any time.
+   *
+   * @platform Android
    */
   getLastPartialResult(): Promise<LastPartialResult>;
   /**
@@ -193,6 +196,7 @@ export interface SpeechRecognitionPlugin {
    * recognition will auto-restart on silence, accumulating results.
    * Call with held=false when the button is released.
    *
+   * @platform Android
    * @param options - PTT state options
    */
   setPTTState(options: PTTStateOptions): Promise<void>;

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -58,6 +58,22 @@ export interface SpeechRecognitionStartOptions {
  */
 export interface SpeechRecognitionPartialResultEvent {
   matches: string[];
+  /**
+   * Accumulated transcription across continuous PTT restarts (Android only).
+   */
+  accumulated?: string;
+  /**
+   * Final accumulated text including the current result (Android only).
+   */
+  accumulatedText?: string;
+  /**
+   * True when recognition is restarting in continuous PTT mode (Android only).
+   */
+  isRestarting?: boolean;
+  /**
+   * True when result was emitted due to force stop timeout (Android only).
+   */
+  forced?: boolean;
 }
 
 /**

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -156,7 +156,9 @@ export interface SpeechRecognitionPlugin {
    * This method:
    * 1. Tries graceful stopListening() first
    * 2. After timeout, forces stop by destroying and recreating the recognizer
-   * 3. Returns the last cached partial result so no speech is lost
+   * 3. Emits the last cached partial result via the `partialResults` event
+   *
+   * To retrieve the last transcription after force stop, use {@link getLastPartialResult}.
    *
    * @param options - Optional timeout configuration
    */

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -44,6 +44,13 @@ export interface SpeechRecognitionStartOptions {
    * Required to be greater than zero and currently supported on Android only.
    */
   allowForSilence?: number;
+  /**
+   * EXPERIMENTAL: Enable continuous PTT mode.
+   * When enabled and used with setPTTState(), recognition will auto-restart on silence
+   * while the PTT button is held, accumulating results across restarts.
+   * Android only.
+   */
+  continuousPTT?: boolean;
 }
 
 /**
@@ -112,6 +119,17 @@ export interface LastPartialResult {
   matches?: string[];
 }
 
+/**
+ * Options for setPTTState method.
+ */
+export interface PTTStateOptions {
+  /**
+   * Whether the PTT button is currently held.
+   * Set to true on button press, false on button release.
+   */
+  held: boolean;
+}
+
 export interface SpeechRecognitionPlugin {
   /**
    * Checks whether the native speech recognition service is usable on the current device.
@@ -150,6 +168,16 @@ export interface SpeechRecognitionPlugin {
    * or checking the current partial state at any time.
    */
   getLastPartialResult(): Promise<LastPartialResult>;
+  /**
+   * EXPERIMENTAL: Set PTT button state for continuous PTT mode.
+   *
+   * When continuousPTT is enabled in start() and held is true,
+   * recognition will auto-restart on silence, accumulating results.
+   * Call with held=false when the button is released.
+   *
+   * @param options - PTT state options
+   */
+  setPTTState(options: PTTStateOptions): Promise<void>;
   /**
    * Gets the locales supported by the underlying recognizer.
    *

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -83,6 +83,35 @@ export interface SpeechRecognitionListening {
   listening: boolean;
 }
 
+/**
+ * Options for the forceStop method.
+ */
+export interface ForceStopOptions {
+  /**
+   * Timeout in milliseconds before forcing stop via destroy/recreate.
+   * Defaults to 1500ms.
+   */
+  timeout?: number;
+}
+
+/**
+ * Result from getLastPartialResult.
+ */
+export interface LastPartialResult {
+  /**
+   * Whether a partial result is available.
+   */
+  available: boolean;
+  /**
+   * The last partial transcription text.
+   */
+  text: string;
+  /**
+   * All partial match alternatives.
+   */
+  matches?: string[];
+}
+
 export interface SpeechRecognitionPlugin {
   /**
    * Checks whether the native speech recognition service is usable on the current device.
@@ -99,6 +128,28 @@ export interface SpeechRecognitionPlugin {
    * Stops listening and tears down native resources.
    */
   stop(): Promise<void>;
+  /**
+   * Force stops recognition with a timeout fallback.
+   *
+   * This is useful for Push-to-Talk (PTT) implementations where you need
+   * reliable stopping behavior. The Android SpeechRecognizer.stopListening()
+   * doesn't always stop audio capture reliably.
+   *
+   * This method:
+   * 1. Tries graceful stopListening() first
+   * 2. After timeout, forces stop by destroying and recreating the recognizer
+   * 3. Returns the last cached partial result so no speech is lost
+   *
+   * @param options - Optional timeout configuration
+   */
+  forceStop(options?: ForceStopOptions): Promise<void>;
+  /**
+   * Gets the last cached partial transcription result.
+   *
+   * Useful for retrieving what was heard before a force stop,
+   * or checking the current partial state at any time.
+   */
+  getLastPartialResult(): Promise<LastPartialResult>;
   /**
    * Gets the locales supported by the underlying recognizer.
    *

--- a/src/web.ts
+++ b/src/web.ts
@@ -1,6 +1,9 @@
 import { WebPlugin } from '@capacitor/core';
 
 import type {
+  ForceStopOptions,
+  LastPartialResult,
+  PTTStateOptions,
   SpeechRecognitionAvailability,
   SpeechRecognitionLanguages,
   SpeechRecognitionListening,
@@ -20,6 +23,18 @@ export class SpeechRecognitionWeb extends WebPlugin implements SpeechRecognition
   }
 
   stop(): Promise<void> {
+    throw this.unimplemented('Speech recognition is not available on the web.');
+  }
+
+  forceStop(_options?: ForceStopOptions): Promise<void> {
+    throw this.unimplemented('Speech recognition is not available on the web.');
+  }
+
+  getLastPartialResult(): Promise<LastPartialResult> {
+    throw this.unimplemented('Speech recognition is not available on the web.');
+  }
+
+  setPTTState(_options: PTTStateOptions): Promise<void> {
     throw this.unimplemented('Speech recognition is not available on the web.');
   }
 


### PR DESCRIPTION
## What
- Add `forceStop()` method for reliable PTT button release on Android
- Add `continuousPTT` mode that auto-restarts recognition on silence
- Add `setPTTState()` and `getLastPartialResult()` methods
- Add PTT demo to example-app with interactive UI
- Add web.ts stubs for new methods

## Why
Android's `SpeechRecognizer.stopListening()` doesn't reliably stop audio capture, breaking PTT user expectations. The new `forceStop()` uses a destroy/recreate pattern with configurable timeout to guarantee stop.

The `continuousPTT` mode allows recognition to continue through silence periods while the PTT button is held, accumulating results across restart cycles.

## How
- `forceStop()`: Tries graceful stop first, then after timeout destroys and recreates the SpeechRecognizer
- `continuousPTT`: Auto-restarts on `ERROR_NO_MATCH` or `ERROR_SPEECH_TIMEOUT` while button is held
- `setPTTState()`: Tracks button press/release state for continuousPTT logic
- `getLastPartialResult()`: Returns cached partial transcription
- Example app: Added PTT toggle, continuousPTT checkbox, and interactive hold-to-talk button

## Testing
- Tested PTT mode on physical Android device (SM-G960U1, Android 10)
- Verified `forceStop()` reliably stops recognition
- Verified `continuousPTT` mode restarts on silence and accumulates results
- Verified example app UI toggles correctly between regular and PTT modes
- Ran `bun run fmt`, `bun run lint`, `bun run verify:web`

## Not Tested
- iOS (these features are Android-only for now)
- `verify:ios` and `verify:android` (requires macOS/Java setup)

---
🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Push-to-Talk (PTT) with continuous mode on Android, hold-to-talk UI and accumulated partial results in the example app.
  * New public APIs to control PTT state, force-stop listening, and retrieve the last partial result.

* **Documentation**
  * Updated API docs and public types/options for PTT, forceStop, getLastPartialResult, setPTTState; adjusted start options and related event/type values.

* **Chores**
  * Aligned Kotlin stdlib version in example build configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->