### PR TITLE
feat(android): implement deterministic state machine for speech recog…

### DIFF
--- a/IMPLEMENTATION_SUMMARY.md
+++ b/IMPLEMENTATION_SUMMARY.md
@@ -1,0 +1,496 @@
+# Deterministic State Machine Implementation Summary
+
+## Overview
+
+This document describes the refactoring of the `@capgo/capacitor-speech-recognition` Android plugin to implement a deterministic finite state machine that fixes critical issues with silence handling, missing events, and race conditions during quick start/stop sequences.
+
+## Problems Solved
+
+### 1. Missing "started" Event During Silence
+
+**Problem:** When the user taps "start listening" but remains silent, Android's `SpeechRecognizer` sometimes never calls `onReadyForSpeech()` or `onBeginningOfSpeech()`. As a result, the plugin never emitted a `listeningState: 'started'` event, leaving the UI in an inconsistent state.
+
+**Solution:** The `started` event is now emitted **immediately after `startListening()` succeeds**, regardless of whether the user speaks. This guarantees the UI receives a deterministic signal that listening has begun.
+
+```java
+// In beginListening() after startListening() succeeds:
+state = ListeningState.STARTED;
+JSObject startedPayload = new JSObject();
+startedPayload.put("state", "started");
+startedPayload.put("sessionId", currentSessionId);
+startedPayload.put("reason", "userStart");
+startedPayload.put("status", "started"); // backward compatibility
+notifyListeners(LISTENING_EVENT, startedPayload);
+```
+
+### 2. Swallowed Errors on Silence
+
+**Problem:** When the user stays completely silent, Android calls `onError(ERROR_NO_MATCH)` or `ERROR_SPEECH_TIMEOUT`. The original plugin swallowed these errors without emitting events or informing the JavaScript side, causing the UI to hang.
+
+**Solution:** All errors now emit an `error` event with detailed information, followed by a proper session termination:
+
+```java
+@Override
+public void onError(int error) {
+    String errorCode = getErrorCode(error);
+    String errorMessage = getErrorText(error);
+    
+    // Always emit error event — never swallow errors
+    JSObject errorPayload = new JSObject();
+    errorPayload.put("code", errorCode); // e.g., "NO_MATCH", "SPEECH_TIMEOUT"
+    errorPayload.put("message", errorMessage);
+    errorPayload.put("sessionId", currentSessionId);
+    notifyListeners(ERROR_EVENT, errorPayload);
+    
+    // Determine reason and finish session
+    String reason = (error == ERROR_NO_MATCH || error == ERROR_SPEECH_TIMEOUT) 
+        ? "silence" : "error";
+    finishSession(currentSessionId, reason, errorCode);
+}
+```
+
+### 3. "Stuck" Recognizer After Quick Start/Stop
+
+**Problem:** When the user taps start then quickly taps stop (within 1-2 seconds) without speaking, the internal `SpeechRecognizer` gets into a bad state. Subsequent `start()` calls succeed on the JS side but the mic icon doesn't appear and no listening happens.
+
+**Solution:** Implemented a unified `finishSession()` method that:
+- Tears down the current recognizer completely (`cancel()` + `destroy()`)
+- Recreates a fresh `SpeechRecognizer` instance on the main thread
+- Emits `readyForNextSession` and `stopped` events after recreation
+- Ignores stale callbacks from old sessions using session ID tracking
+
+```java
+private void finishSession(long finishedSessionId, String reason, String errorCode) {
+    if (finishedSessionId != sessionId) return; // ignore stale callbacks
+    
+    // 1. Tear down current recognizer
+    if (speechRecognizer != null) {
+        speechRecognizer.cancel();
+        speechRecognizer.destroy();
+        speechRecognizer = null;
+    }
+    
+    state = ListeningState.IDLE;
+    readyForNext = false;
+    
+    // 2. Recreate on main thread
+    new Handler(Looper.getMainLooper()).post(() -> {
+        speechRecognizer = SpeechRecognizer.createSpeechRecognizer(...);
+        speechRecognizer.setRecognitionListener(new listener);
+        readyForNext = true;
+        
+        notifyListeners("readyForNextSession", ...);
+        notifyListeners("listeningState", stopped payload);
+    });
+}
+```
+
+## State Machine Design
+
+### States
+
+```java
+private enum ListeningState {
+    IDLE,        // Not listening, ready to start
+    STARTING,    // start() called, emitted startingListening
+    STARTED,     // startListening() succeeded, emitted started
+    STOPPING     // stop() called, emitted stoppingListening
+}
+```
+
+### State Transitions
+
+```
+IDLE → (start()) → STARTING → STARTED → (stop() or results or error) → STOPPING → IDLE
+```
+
+### Session ID Tracking
+
+- Each `start()` call increments `sessionId`
+- All `RecognitionListener` callbacks capture the session ID at construction time
+- Stale callbacks (from old sessions) are ignored
+
+```java
+@Override
+public void onResults(Bundle results) {
+    long currentSessionId = listenerSessionId;
+    // ... process results ...
+    finishSession(currentSessionId, "results", null);
+}
+```
+
+## Event Flow
+
+### Successful Recognition Flow
+
+1. **User calls `start()`**
+   - State: `IDLE` → `STARTING`
+   - Event: `listeningState { state: "startingListening", sessionId: 1, reason: "userStart" }`
+
+2. **`startListening()` succeeds**
+   - State: `STARTING` → `STARTED`
+   - Event: `listeningState { state: "started", sessionId: 1, reason: "userStart", status: "started" }`
+
+3. **User speaks, `onPartialResults()` fires**
+   - Event: `partialResults { matches: ["hello"] }`
+   - (Continues emitting partials as user speaks)
+
+4. **User stops speaking, `onResults()` fires**
+   - Event: `partialResults { matches: ["hello world"] }`
+   - Calls `finishSession(1, "results", null)`
+
+5. **`finishSession()` transitions to STOPPING**
+   - State: `STARTED` → `STOPPING`
+   - Event: `listeningState { state: "stoppingListening", sessionId: 1, reason: "results" }`
+
+6. **`finishSession()` tears down and recreates**
+   - State: `STOPPING` → `IDLE`
+   - Event: `readyForNextSession { sessionId: 1 }`
+   - Event: `listeningState { state: "stopped", sessionId: 1, reason: "results", status: "stopped" }`
+
+### Silence Timeout Flow
+
+1. **User calls `start()`**
+   - Events: `startingListening`, then `started`
+
+2. **User stays silent for 2-3 seconds**
+
+3. **Android calls `onError(ERROR_NO_MATCH)`**
+   - Event: `error { code: "NO_MATCH", message: "No match", sessionId: 1 }`
+   - Calls `finishSession(1, "silence", "NO_MATCH")`
+
+4. **`finishSession()` transitions to STOPPING**
+   - State: `STARTED` → `STOPPING`
+   - Event: `listeningState { state: "stoppingListening", sessionId: 1, reason: "silence", errorCode: "NO_MATCH" }`
+
+5. **`finishSession()` tears down and recreates**
+   - State: `STOPPING` → `IDLE`
+   - Event: `readyForNextSession { sessionId: 1 }`
+   - Event: `listeningState { state: "stopped", sessionId: 1, reason: "silence", errorCode: "NO_MATCH", status: "stopped" }`
+
+### User Stop Flow
+
+1. **User calls `start()`, then immediately `stop()`**
+   - State: `STARTED` → `STOPPING`
+   - Event: `listeningState { state: "stoppingListening", sessionId: 1, reason: "userStop" }`
+
+2. **`finishSession()` is called**
+   - If not already in STOPPING state, transitions to `STOPPING`
+   - Event: `stoppingListening` (if not already emitted by `stop()`)
+
+3. **Android calls `onResults()` or `onError()`**
+   - Event: `error` (if error) or `partialResults` (if results)
+   - Completes `finishSession(1, "userStop" or "results", null)`
+
+4. **`finishSession()` completes teardown**
+   - State: `STOPPING` → `IDLE`
+   - Events: `readyForNextSession`, `stopped`
+
+## New TypeScript API
+
+### Extended Event Interfaces
+
+```typescript
+export type ListeningFiniteState =
+  | 'startingListening'
+  | 'started'
+  | 'stoppingListening'
+  | 'stopped';
+
+export type ListeningReason =
+  | 'userStart'
+  | 'userStop'
+  | 'results'
+  | 'silence'
+  | 'error'
+  | 'unknown';
+
+export interface SpeechRecognitionListeningEvent {
+  // New fields (v7.1+):
+  state?: ListeningFiniteState;
+  sessionId?: number;
+  reason?: ListeningReason;
+  errorCode?: string;
+  
+  // Backward compatible field:
+  status: 'started' | 'stopped';
+}
+
+export interface SpeechRecognitionErrorEvent {
+  code: string;      // "NO_MATCH", "SPEECH_TIMEOUT", "NETWORK", etc.
+  message: string;
+  sessionId: number;
+}
+
+export interface SpeechRecognitionReadyEvent {
+  sessionId: number;
+}
+```
+
+### New Listener Methods
+
+```typescript
+// Listen for errors (previously only via promise rejections)
+SpeechRecognition.addListener('error', (event: SpeechRecognitionErrorEvent) => {
+  if (event.code === 'NO_MATCH') {
+    console.log('User was silent, timeout occurred');
+  }
+});
+
+// Listen for readyForNextSession (low-level, for debugging/retry logic)
+SpeechRecognition.addListener('readyForNextSession', (event) => {
+  console.log('Recognizer recreated, safe to start() again');
+});
+```
+
+## Backward Compatibility
+
+### Existing Code Still Works
+
+All existing consumer code continues to work without changes:
+
+```typescript
+// This code works exactly as before:
+SpeechRecognition.addListener('listeningState', (data) => {
+  if (data.status === 'started') {
+    // UI shows listening indicator
+  } else if (data.status === 'stopped') {
+    // UI hides listening indicator
+  }
+});
+```
+
+### What Changed (Improvements Only)
+
+1. **`started` now always fires** — even during silence
+2. **`stopped` now always fires** — after every session
+3. **New `error` event** — provides visibility into errors that were previously silent
+4. **Extended `listeningState` payload** — includes `state`, `sessionId`, `reason`, `errorCode` (all optional)
+5. **New `readyForNextSession` event** — for advanced use cases
+
+## Error Code Mapping
+
+Android error codes are now mapped to readable strings:
+
+| Android Constant | String Code | Typical Cause |
+|-----------------|-------------|---------------|
+| `ERROR_NO_MATCH` | `"NO_MATCH"` | User was silent, no speech detected |
+| `ERROR_SPEECH_TIMEOUT` | `"SPEECH_TIMEOUT"` | No speech input within timeout |
+| `ERROR_NETWORK` | `"NETWORK"` | Network error (cloud recognition) |
+| `ERROR_AUDIO` | `"AUDIO"` | Audio recording error |
+| `ERROR_CLIENT` | `"CLIENT"` | Client-side error |
+| `ERROR_INSUFFICIENT_PERMISSIONS` | `"INSUFFICIENT_PERMISSIONS"` | Missing microphone permission |
+| `ERROR_RECOGNIZER_BUSY` | `"RECOGNIZER_BUSY"` | Recognizer already in use |
+| `ERROR_SERVER` | `"SERVER"` | Server error (cloud recognition) |
+| Other | `"UNKNOWN_<code>"` | Unknown error code |
+
+## Testing Recommendations
+
+### Test Scenarios
+
+1. **Silence Test**
+   ```
+   - Call start()
+   - Wait for 'started' event (should fire immediately)
+   - Stay silent for 3-5 seconds
+   - Expect 'error' event with code="NO_MATCH"
+   - Expect 'stopped' event with reason="silence"
+   ```
+
+2. **Quick Start/Stop Test**
+   ```
+   - Call start()
+   - Immediately call stop() (within 500ms)
+   - Expect 'stoppingListening' event
+   - Expect 'stopped' event
+   - Wait for 'readyForNextSession'
+   - Call start() again (should work perfectly)
+   ```
+
+3. **Normal Recognition Test**
+   ```
+   - Call start()
+   - Speak "hello world"
+   - Expect partialResults events with increasing text
+   - Expect final results
+   - Expect 'stopped' event with reason="results"
+   ```
+
+4. **Session ID Isolation Test**
+   ```
+   - Call start() (sessionId=1)
+   - Speak a bit
+   - Call stop()
+   - Immediately call start() (sessionId=2)
+   - Verify all events from session 1 have sessionId=1
+   - Verify all events from session 2 have sessionId=2
+   ```
+
+### Logcat Monitoring
+
+Look for these log messages:
+
+```
+[SpeechRecognition] Starting recognition | sessionId=1 ...
+[SpeechRecognition] Emitted 'started' state for sessionId=1
+[SpeechRecognition] Recognizer error: No match (code=NO_MATCH, session=1)
+[SpeechRecognition] Finishing session 1 reason=silence errorCode=NO_MATCH
+[SpeechRecognition] Recognizer recreated, ready for next session
+[SpeechRecognition] Emitted 'stopped' state for sessionId=1
+```
+
+## Migration Guide for Consumers
+
+### If You Currently Use `listeningState`
+
+No changes required. Your code will continue to work exactly as before.
+
+**Optional improvements:**
+
+```typescript
+// Before (still works):
+SpeechRecognition.addListener('listeningState', (event) => {
+  if (event.status === 'started') { /* ... */ }
+});
+
+// After (more visibility):
+SpeechRecognition.addListener('listeningState', (event) => {
+  console.log('Session', event.sessionId, 'state:', event.state, 'reason:', event.reason);
+  if (event.status === 'started') { /* ... */ }
+});
+```
+
+### If You Want to Handle Silence Gracefully
+
+```typescript
+SpeechRecognition.addListener('error', (event) => {
+  if (event.code === 'NO_MATCH' || event.code === 'SPEECH_TIMEOUT') {
+    // User was silent, this is expected behavior
+    console.log('Silence timeout, automatically restarting...');
+    setTimeout(() => SpeechRecognition.start({ ... }), 100);
+  } else {
+    // Actual error (network, permissions, etc.)
+    showErrorToUser(event.message);
+  }
+});
+```
+
+### If You Had Workarounds for Stuck Recognizer
+
+You can now remove your workarounds. The plugin guarantees:
+- Every session ends with a `stopped` event
+- The recognizer is fully torn down and recreated after each session
+- Session IDs prevent stale callbacks from interfering
+
+## Implementation Details
+
+### Key Files Changed
+
+1. **`android/src/main/java/app/capgo/speechrecognition/SpeechRecognitionPlugin.java`**
+   - Added `ListeningState` enum
+   - Added `sessionId` and `readyForNext` fields
+   - Refactored `start()` to emit `startingListening` and `started`
+   - Refactored `stop()` to emit `stoppingListening`
+   - Added `finishSession()` helper
+   - Updated `SpeechRecognitionListener` to track session ID
+   - Changed `onBeginningOfSpeech()` to no-op (we emit started earlier)
+   - Changed `onEndOfSpeech()` to no-op (we emit stopped in finishSession)
+   - Changed `onError()` to always emit `error` event and call `finishSession()`
+   - Changed `onResults()` to call `finishSession()` after processing
+   - Added `getErrorCode()` helper for error code mapping
+
+2. **`android/src/main/java/app/capgo/speechrecognition/Constants.java`**
+   - Added `ERROR_EVENT = "error"`
+   - Added `READY_FOR_NEXT_SESSION_EVENT = "readyForNextSession"`
+
+3. **`src/definitions.ts`**
+   - Added `ListeningFiniteState` type
+   - Added `ListeningReason` type
+   - Extended `SpeechRecognitionListeningEvent` with optional new fields
+   - Added `SpeechRecognitionErrorEvent` interface
+   - Added `SpeechRecognitionReadyEvent` interface
+   - Added `error` listener method
+   - Added `readyForNextSession` listener method
+
+### Thread Safety
+
+- All state mutations are protected by `lock` (ReentrantLock)
+- Recognizer teardown and recreation happens on the main thread
+- Event emissions happen on Capacitor's bridge thread
+
+### Memory Management
+
+- Old recognizer instances are explicitly destroyed before creating new ones
+- Listener callbacks hold session ID by value, not reference
+- No memory leaks from stale callbacks (they return early if session ID doesn't match)
+
+## Guarantees
+
+After this refactoring, the plugin guarantees:
+
+1. ✅ **`started` event always fires** after successful `start()`, even if the user is silent
+2. ✅ **`stopped` event always fires** when a session ends (results, error, or user stop)
+3. ✅ **`error` events are never swallowed** — all errors are visible to JavaScript
+4. ✅ **Every session has a unique ID** — no confusion between concurrent or sequential sessions
+5. ✅ **Recognizer is fully reset** between sessions — no "stuck" state
+6. ✅ **Backward compatibility preserved** — existing code works without changes
+7. ✅ **Thread-safe state machine** — no race conditions
+
+## Next Steps
+
+1. **Build the plugin:**
+   ```bash
+   bun run build
+   ```
+
+2. **Verify for all platforms:**
+   ```bash
+   bun run verify
+   ```
+
+3. **Test in example app:**
+   ```bash
+   cd example-app
+   bun install
+   bunx cap sync android
+   bun run start
+   ```
+
+4. **Test the three problematic scenarios:**
+   - Start → silence → wait for error event
+   - Start → immediate stop → verify clean shutdown
+   - Rapid start/stop/start → verify no "stuck" state
+
+5. **Update README.md:**
+   - Document the new `error` event
+   - Document the extended `listeningState` payload
+   - Add migration guide
+   - Add examples for handling silence
+
+6. **Update CHANGELOG.md:**
+   ```markdown
+   ## [7.1.0] - 2026-02-22
+   
+   ### Added
+   - Deterministic state machine for Android speech recognition
+   - `error` event now emitted for all recognition errors
+   - `readyForNextSession` event for session lifecycle visibility
+   - Extended `listeningState` event with `state`, `sessionId`, `reason`, `errorCode`
+   - Session ID tracking to prevent stale callback interference
+   
+   ### Fixed
+   - `started` event now always fires, even during complete silence
+   - Errors during silence (NO_MATCH, SPEECH_TIMEOUT) are no longer swallowed
+   - Quick start/stop sequences no longer leave recognizer in "stuck" state
+   - Race conditions between startListening, stopListening, and error callbacks
+   
+   ### Changed
+   - Recognizer is now fully torn down and recreated between sessions
+   - Error codes mapped to readable strings (e.g., "NO_MATCH", "NETWORK")
+   ```
+
+## Conclusion
+
+This refactoring transforms the Android speech recognition plugin from an unreliable, event-driven system into a **deterministic finite state machine** that provides complete visibility into the recognition lifecycle. The UI can now fully trust the plugin's events and never needs to "guess" what Android is doing behind the scenes.
+
+The implementation maintains 100% backward compatibility while adding powerful new features for error handling, session tracking, and lifecycle management.

--- a/android/src/main/java/app/capgo/speechrecognition/Constants.java
+++ b/android/src/main/java/app/capgo/speechrecognition/Constants.java
@@ -12,6 +12,8 @@ public interface Constants {
     String END_OF_SEGMENT_EVENT = "endOfSegmentedSession";
     String LISTENING_EVENT = "listeningState";
     String PARTIAL_RESULTS_EVENT = "partialResults";
+    String ERROR_EVENT = "error";
+    String READY_FOR_NEXT_SESSION_EVENT = "readyForNextSession";
     String RECORD_AUDIO_PERMISSION = Manifest.permission.RECORD_AUDIO;
     String LANGUAGE_ERROR = "Could not get list of languages";
 }

--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "swiftlint": "node-swiftlint",
     "docgen": "docgen --api SpeechRecognitionPlugin --output-readme README.md --output-json dist/docs.json",
     "build": "npm run clean && npm run docgen && tsc && rollup -c rollup.config.mjs",
+    "prepare": "npm run build",
     "clean": "rimraf ./dist",
     "watch": "tsc --watch",
     "prepublishOnly": "npm run build",


### PR DESCRIPTION
…nition

- Introduced a finite state machine to manage listening sessions, improving predictability and observability.
- Emitted events for state transitions: `startingListening`, `started`, `stoppingListening`, and `stopped`.
- Enhanced error handling by emitting an `error` event for all recognition errors.
- Added `readyForNextSession` event to signal when the recognizer is ready for a new session.
- Maintained backward compatibility while improving session management and UI responsiveness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deterministic listening lifecycle (startingListening → started → stoppingListening → stopped).
  * Per-start sessionId included in listening events and error payloads.
  * Always-emitted error event with stable codes and readyForNextSession signal.
  * Extended listeningState with state, reason, sessionId, and errorCode.

* **Bug Fixes**
  * Robust start/stop handling that ignores stale callbacks and prevents races.
  * Consistent error-driven progression and improved event ordering.

* **Documentation**
  * New implementation summary, README updates, migration guidance, and test recommendations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->